### PR TITLE
moving epsilon outside softplus

### DIFF
--- a/network/continuous_action_network.py
+++ b/network/continuous_action_network.py
@@ -145,7 +145,7 @@ class GaussianActorNet(nn.Module, BasicNet):
             log_std = self.action_log_std.expand_as(mean)
             std = log_std.exp()
         else:
-            std = F.softplus(self.action_std(phi) + 1e-5)
+            std = F.softplus(self.action_std(phi)) + 1e-5
             log_std = std.log()
         return mean, std, log_std
 


### PR DESCRIPTION
I think you intended this to be outside the softplus. This code illustrates why:


```python
# eps=1e-5 is inside softplus => inf
x = torch.FloatTensor([-1000])
x=F.softplus(x + 1e-5)
print(x.log())
# Variable containing:
# -inf
# [torch.FloatTensor of size 1]

# eps=1e-5 is outside softplus, no inf
x = torch.FloatTensor([-1000])
x=F.softplus(x) + 1e-5
print(x.log())
# Variable containing:
# -11.5129
# [torch.FloatTensor of size 1]


```

Also this fixes a NaN I had.