### PR TITLE
add eps to log_density to avoid NaN

### DIFF
--- a/network/continuous_action_network.py
+++ b/network/continuous_action_network.py
@@ -154,7 +154,7 @@ class GaussianActorNet(nn.Module, BasicNet):
 
     def log_density(self, x, mean, log_std, std):
         var = std.pow(2)
-        log_density = -(x - mean).pow(2) / (2 * var) - 0.5 * torch.log(2 * Variable(torch.FloatTensor([np.pi])).expand_as(x)) - log_std
+        log_density = -(x - mean).pow(2) / (2 * var + 1e-5) - 0.5 * torch.log(2 * Variable(torch.FloatTensor([np.pi])).expand_as(x)) - log_std
         return log_density.sum(1)
 
     def entropy(self, std):


### PR DESCRIPTION
I tracked some NaN's I was getting down to here. It happens when std is a small number, then var is even smaller, and log_density becomes inf. 

There are some problems where the agent will learn to use small standard deviations because jittering movements have a high cost. These are the problem when this can occur.