### PR TITLE
entropy equation?

### DIFF
--- a/network/continuous_action_network.py
+++ b/network/continuous_action_network.py
@@ -158,7 +158,7 @@ class GaussianActorNet(nn.Module, BasicNet):
         return log_density.sum(1)
 
     def entropy(self, std):
-        return 0.5 * (1 + (2 * std.pow(2) * np.pi + 1e-5).log()).sum(1).mean()
+        return 0.5 * (2 * var * np.pi * np.e).log().sum(1).mean()
 
 class GaussianCriticNet(nn.Module, BasicNet):
     def __init__(self, state_dim, gpu=False):

--- a/network/continuous_action_network.py
+++ b/network/continuous_action_network.py
@@ -158,6 +158,7 @@ class GaussianActorNet(nn.Module, BasicNet):
         return log_density.sum(1)
 
     def entropy(self, std):
+        var = std.pow(2) + 1e-5
         return 0.5 * (2 * var * np.pi * np.e).log().sum(1).mean()
 
 class GaussianCriticNet(nn.Module, BasicNet):


### PR DESCRIPTION
Feel free to leave this if you're busy. Sorry for creating so many PR's! I just think it's a shame that so many RL libraries have critical bugs so I'm trying to point any out that I see. Not sure this is a bug though.

I was trying to check the equation you used for gaussian entropy, it's quite different than the [tensorforce](https://github.com/reinforceio/tensorforce/blob/master/tensorforce/core/distributions/gaussian.py#L93) one, and the one at eq8.18 [here](http://www.biopsychology.org/norwich/isp/chap8.pdf). Particularly the `+1`, so I was wondering if that was a bug or perhaps you used a differen't derivation.